### PR TITLE
This is not a bug, but rather a Spring feature. When entered invalid …

### DIFF
--- a/src/main/java/greencity/annotations/ApiPageable.java
+++ b/src/main/java/greencity/annotations/ApiPageable.java
@@ -11,9 +11,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @ApiImplicitParams({
     @ApiImplicitParam(name = "page", dataType = "int", paramType = "query", defaultValue = "0",
-        value = "Results page you want to retrieve (0..N)"),
+        value = "Results page you want to retrieve (0..N). "
+                + "If page index is less than 0 or not specified then default value is 0."),
     @ApiImplicitParam(name = "size", dataType = "int", paramType = "query", defaultValue = "5",
-        value = "Number of records per page."),
+        value = "Number of records per page (1..N). "
+                + "If size is less than 1 or not specified, then default value is 20."),
     @ApiImplicitParam(name = "sort", allowMultiple = true, dataType = "string", paramType = "query",
         value = "Sorting criteria in the format: property(,asc|desc). "
             + "Default sort order is ascending. " + "Multiple sort criteria are supported.")})

--- a/src/main/java/greencity/config/PageableConfig.java
+++ b/src/main/java/greencity/config/PageableConfig.java
@@ -1,0 +1,21 @@
+package greencity.config;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class PageableConfig implements WebMvcConfigurer {
+    /**
+     * Sets max page size for pageables objects.
+     */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        PageableHandlerMethodArgumentResolver resolver = new PageableHandlerMethodArgumentResolver();
+        resolver.setMaxPageSize(100);
+        argumentResolvers.add(resolver);
+        WebMvcConfigurer.super.addArgumentResolvers(argumentResolvers);
+    }
+}

--- a/src/main/java/greencity/controller/UserController.java
+++ b/src/main/java/greencity/controller/UserController.java
@@ -22,7 +22,6 @@ import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
@@ -91,6 +90,7 @@ public class UserController {
     @ApiOperation(value = "Get users by page")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK, response = PageableDto.class),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN)
     })
     @ApiPageable


### PR DESCRIPTION
This is not a bug, but rather a Spring feature. When entered invalid data, for instance, page index (less than 0) or size (less than 1), Spring uses its default Pageable object with page
equals to 0 and size equals to 20. I can override the default Pageable
object with different values, but I cannot make it throw an exception. We'd better leave as it is now and avoid creating a bicycle.

I modified ApiPageable annotation, added ApiResponce with code = 400 to
the corresponding controller and deleted unused import, created Pageable
configuration with max Pageable size = 100.